### PR TITLE
Remove --talk-name=org.gtk.vfs

### DIFF
--- a/org.gnome.font-viewer.json
+++ b/org.gnome.font-viewer.json
@@ -9,7 +9,6 @@
         "--share=ipc",
         "--socket=wayland",
         "--socket=fallback-x11",
-        "--talk-name=org.gtk.vfs",
         "--talk-name=org.gtk.vfs.*",
         "--filesystem=xdg-data/fonts:create"
     ],


### PR DESCRIPTION
This is always wrong according to
https://docs.flatpak.org/en/latest/sandbox-permissions.html#gvfs-access